### PR TITLE
Add support for Software Codes for Environment Lookup.

### DIFF
--- a/app.py
+++ b/app.py
@@ -261,14 +261,16 @@ class CpenvApplication(sgtk.platform.Application):
         module_paths = self.get_setting('module_paths') or []
         self.set_module_paths(module_paths)
 
-        # Get engine name
+        # Get engine or software code
+        software = None
+        engine = engine_name
         if software_entity:
+            software = software_entity.get('code')
             engine = software_entity.get('engine', engine_name)
-        else:
-            engine = engine_name
 
         # Get Environment for engine
         environments = self.io.get_environments(
+            software=software,
             engine=engine,
             user=self.context.user,
             software_versions=version,
@@ -330,6 +332,7 @@ class CpenvIO(object):
     def get_environment(
         self,
         project=None,
+        software=None,
         engine=None,
         name=None,
         user=None,
@@ -359,8 +362,17 @@ class CpenvIO(object):
                     ['sg_permissions_users', 'is', None],
                 ]
             })
-        if engine:
-            filters.append(['sg_engine', 'is', engine])
+        if software or engine:
+            sw_engine_filters = []
+            if software:
+                sw_engine_filters.append(['sg_engine', 'is', software])
+            if engine:
+                sw_engine_filters.append(['sg_engine', 'is', engine])
+            sw_engine_filters = {
+                'filter_operator': 'any',
+                'filters': sw_engine_filters,
+            }
+            filters.append(sw_engine_filters)
         if name:
             filters.append(['code', 'is', name])
         if requires:
@@ -387,6 +399,7 @@ class CpenvIO(object):
     def get_environments(
         self,
         project=None,
+        software=None,
         engine=None,
         name=None,
         user=None,
@@ -415,8 +428,17 @@ class CpenvIO(object):
                     ['sg_permissions_users', 'is', None],
                 ]
             })
-        if engine:
-            filters.append(['sg_engine', 'is', engine])
+        if software or engine:
+            sw_engine_filters = []
+            if software:
+                sw_engine_filters.append(['sg_engine', 'is', software])
+            if engine:
+                sw_engine_filters.append(['sg_engine', 'is', engine])
+            sw_engine_filters = {
+                'filter_operator': 'any',
+                'filters': sw_engine_filters,
+            }
+            filters.append(sw_engine_filters)
         if name:
             filters.append(['code', 'is', name])
         if requires:
@@ -551,15 +573,28 @@ class CpenvIO(object):
         )
 
     def get_engines(self):
-        '''Get a list of engine names from configured Software entities.'''
+        '''Get a list of engine names and codes from configured Software entities.
 
-        entities = self.shotgun.find('Software', [], ['engine'])
+        Prior to 0.5.10, this method only returned engine names. However, some Software
+        entities do not have toolkit engines, so we now return software codes as well.
+        '''
+
+        entities = self.shotgun.find(
+            'Software',
+            filters=[['sg_status_list', 'is', 'act']],
+            fields=['engine', 'code'],
+        )
         if not entities:
             return []
 
-        return list(
-            sorted(set([e['engine'] for e in entities if e['engine']]))
-        )
+        entities = sorted(entities, key=lambda e: e.get('code', e.get('engine', '')))
+        results = []
+        for entity in entities:
+            if entity.get('code') and entity.get('code') not in results:
+                results.append(entity['code'])
+            if entity.get('engine') and entity.get('engine') not in results:
+                results.append(entity['engine'])
+        return list(results)
 
     def get_module_spec_sets(self):
         '''Get a list of all the Modules stored in Shotgun.

--- a/app.py
+++ b/app.py
@@ -576,7 +576,8 @@ class CpenvIO(object):
         '''Get a list of engine names and codes from configured Software entities.
 
         Prior to 0.5.10, this method only returned engine names. However, some Software
-        entities do not have toolkit engines, so we now return software codes as well.
+        entities do not have toolkit engines, so we now return software codes for those
+        entties.
         '''
 
         entities = self.shotgun.find(
@@ -588,12 +589,22 @@ class CpenvIO(object):
             return []
 
         entities = sorted(entities, key=lambda e: e.get('code', e.get('engine', '')))
+
         results = []
         for entity in entities:
-            if entity.get('code') and entity.get('code') not in results:
-                results.append(entity['code'])
-            if entity.get('engine') and entity.get('engine') not in results:
-                results.append(entity['engine'])
+
+            engine, software = entity.get('engine'), entity.get('code')
+
+            if engine in results or software in results:
+                continue
+
+            if engine:
+                results.append(engine)
+                continue
+
+            if software:
+                results.append(software)
+
         return list(results)
 
     def get_module_spec_sets(self):

--- a/python/cpenv_ui/module_selector.py
+++ b/python/cpenv_ui/module_selector.py
@@ -122,12 +122,9 @@ class ModuleSelector(QtGui.QWidget):
         self.env_header.addWidget(self.env_preview)
         self.env_header.addWidget(self.env_lock)
 
-        self.engine_label = QtGui.QLabel('Engine')
+        self.engine_label = QtGui.QLabel('Engine or Software')
         self.engine_label.setToolTip(
-            'The toolkit engine this environment applies to.'
-        )
-        self.engine_label.setToolTip(
-            'Select a toolkit engine this environment applies to.'
+            'Select an Engine or Software this environment applies to.'
         )
         self.engine_list = QtGui.QComboBox()
         self.engine_list.setFixedHeight(24)


### PR DESCRIPTION
This PR adds support for looking up Environments using the `Software.code` field rather than just the toolkit engine name. This means that tk-cpenv can resolve Environments for Software entities that have no toolkit engine!

The Engine combo box now includes Software codes for entities that have no associated engine name and the label reads `Engine or Software`.