### PR TITLE
Improve exception handling in permissions dialog

### DIFF
--- a/python/cpenv_ui/env_permissions.py
+++ b/python/cpenv_ui/env_permissions.py
@@ -2,7 +2,6 @@
 from __future__ import print_function
 
 # Standard library imports
-import traceback
 
 # Shotgun imports
 import sgtk
@@ -53,17 +52,15 @@ class EnvPermissions(QtGui.QDialog):
 
     def on_initialized(self):
         app.debug('ON_INITIALIZED')
-        try:
-            self.editor = self._fields_manager.create_widget(
-                sg_entity_type=self.state['environment']['type'],
-                field_name='sg_permissions_users',
-                widget_type=self._fields_manager.EDITOR,
-                entity=self.state['environment'],
-                parent=self,
-            )
-            self.layout.insertWidget(1, self.editor)
-        except Exception:
-            app.debug(traceback.format_exc())
+
+        self.editor = self._fields_manager.create_widget(
+            sg_entity_type=self.state['environment']['type'],
+            field_name='sg_permissions_users',
+            widget_type=self._fields_manager.EDITOR,
+            entity=self.state['environment'],
+            parent=self,
+        )
+        self.layout.insertWidget(1, self.editor)
 
     def on_cancel_clicked(self):
         self.reject()
@@ -71,13 +68,10 @@ class EnvPermissions(QtGui.QDialog):
     def on_save_clicked(self):
         users = self.editor.get_value()
 
-        try:
-            app.io.set_environment_permissions(
-                self.state['environment']['id'],
-                users,
-            )
-            self.state['environment']['sg_permissions_users'] = users
-        except Exception:
-            app.debug(traceback.format_exc())
+        app.io.set_environment_permissions(
+            self.state['environment']['id'],
+            users,
+        )
+        self.state['environment']['sg_permissions_users'] = users
 
         self.accept()

--- a/python/cpenv_ui/env_permissions.py
+++ b/python/cpenv_ui/env_permissions.py
@@ -52,15 +52,17 @@ class EnvPermissions(QtGui.QDialog):
 
     def on_initialized(self):
         app.debug('ON_INITIALIZED')
-
-        self.editor = self._fields_manager.create_widget(
-            sg_entity_type=self.state['environment']['type'],
-            field_name='sg_permissions_users',
-            widget_type=self._fields_manager.EDITOR,
-            entity=self.state['environment'],
-            parent=self,
-        )
-        self.layout.insertWidget(1, self.editor)
+        try:
+            self.editor = self._fields_manager.create_widget(
+                sg_entity_type=self.state['environment']['type'],
+                field_name='sg_permissions_users',
+                widget_type=self._fields_manager.EDITOR,
+                entity=self.state['environment'],
+                parent=self,
+            )
+            self.layout.insertWidget(1, self.editor)
+        except Exception:
+            app.logger.exception('Error occurred during Permission Dialog initialization.')
 
     def on_cancel_clicked(self):
         self.reject()
@@ -68,10 +70,13 @@ class EnvPermissions(QtGui.QDialog):
     def on_save_clicked(self):
         users = self.editor.get_value()
 
-        app.io.set_environment_permissions(
-            self.state['environment']['id'],
-            users,
-        )
-        self.state['environment']['sg_permissions_users'] = users
+        try:
+            app.io.set_environment_permissions(
+                self.state['environment']['id'],
+                users,
+            )
+            self.state['environment']['sg_permissions_users'] = users
+        except Exception:
+            app.logger.exception('Error occurred during save in Permission Dialog.')
 
         self.accept()

--- a/python/cpenv_ui/module_selector.py
+++ b/python/cpenv_ui/module_selector.py
@@ -407,9 +407,8 @@ class ModuleSelector(QtGui.QWidget):
             if save:
                 self._update_env_lock()
         except Exception:
-            app.logger.exception('Error occurred with Permissions Dialog.')
             error_message = ErrorDialog(
-                label='Error occurred with Permissions Dialog.',
+                label='Failed to open Permissions Dialog.',
                 message=traceback.format_exc(),
                 parent=self,
             )

--- a/python/cpenv_ui/module_selector.py
+++ b/python/cpenv_ui/module_selector.py
@@ -407,8 +407,9 @@ class ModuleSelector(QtGui.QWidget):
             if save:
                 self._update_env_lock()
         except Exception:
+            app.logger.exception('Error occurred with Permissions Dialog.')
             error_message = ErrorDialog(
-                label='Failed to open Permissions Dialog.',
+                label='Error occurred with Permissions Dialog.',
                 message=traceback.format_exc(),
                 parent=self,
             )


### PR DESCRIPTION
Errors during initialization and saving of the Permissions dialog are now correctly logged to the SGTK log files and console.

Fixes #20 