### PR TITLE
Fix condition for showing environment selector.

### DIFF
--- a/app.py
+++ b/app.py
@@ -281,7 +281,7 @@ class CpenvApplication(sgtk.platform.Application):
 
         self.debug('Found Environments: %s', environments)
 
-        if len(environments) == 2:
+        if len(environments) >= 2:
             env = self.show_environment_selector(environments)
         else:
             env = environments[0]


### PR DESCRIPTION
Addresses a bug where the environment selector dialog was not triggered when more than 2 were available for a user.

Fixes #23 