### PR TITLE
Fix for OverflowError int larger than maximum 32-bit integer

### DIFF
--- a/python/cpenv_ui/dialogs.py
+++ b/python/cpenv_ui/dialogs.py
@@ -77,7 +77,15 @@ class ProgressDialog(QtGui.QDialog):
 
     def set_progress(self, chunk_size=None, max_size=None):
         if max_size:
+            if max_size != 1:
+                if len(str(max_size)) > 9:
+                    # Fix for OverflowError int larger than maximum 32-bit integer
+                    # not super elegant, but it works
+                    max_size = max_size / 1000
             self.progress.setRange(0, max_size)
+            self.progress.setValue(0)
+            self.progress.setFormat('0%')
+            self.progress.setRange(0, int(max_size))
             self.progress.setValue(0)
             self.progress.setFormat('0%')
         if chunk_size:


### PR DESCRIPTION
This patch fixes an overfow error in the QProgressBar which crashes the tk-cpenv activation flow if the size of the package, in bytes/int, is larger than then the maximum value for a 32 bit integer.
Not super elegant, but it works.

This happens when you use CPENV for managing software packages that can easily get larger than 2GB.

It's worth noting that the field that holds the size value in bytes on Flow has to be converted to a Text field as directed by the API error that is returned when publishing your package.

Fixes #29 