### PR TITLE
Add support for PySide6.

### DIFF
--- a/python/cpenv_ui/env_display.py
+++ b/python/cpenv_ui/env_display.py
@@ -16,7 +16,6 @@ from . import res
 from .env_tree import EnvTree
 from .notice import Notice
 
-
 app = sgtk.platform.current_bundle()
 
 
@@ -39,7 +38,7 @@ class EnvDisplay(QtGui.QDialog):
         self.copy_button.clicked.connect(self.copy_to_clipboard)
 
         self.button_layout = QtGui.QHBoxLayout()
-        self.button_layout.setDirection(self.button_layout.RightToLeft)
+        self.button_layout.setDirection(QtGui.QHBoxLayout.RightToLeft)
         self.button_layout.addWidget(self.ok_button)
         self.button_layout.addWidget(self.copy_button)
         self.button_layout.addStretch()

--- a/python/cpenv_ui/env_tree.py
+++ b/python/cpenv_ui/env_tree.py
@@ -46,9 +46,9 @@ class EnvTree(QtGui.QTreeWidget):
         # Setup header
         self.setHeaderLabels(['Key', 'Value'])
         header = self.header()
-        header.setSectionResizeMode(header.ResizeToContents)
+        header.setSectionResizeMode(QtGui.QHeaderView.ResizeToContents)
         header.setStretchLastSection(False)
-        header.setSectionResizeMode(Value, header.Stretch)
+        header.setSectionResizeMode(Value, QtGui.QHeaderView.Stretch)
 
         self.set_data(data)
 
@@ -74,13 +74,13 @@ class EnvTree(QtGui.QTreeWidget):
                     child.setText(Key, key)
                 parent_item.addChild(child)
             else:
-                item = QtGui.QTreeWidgetItem(parent=self)
+                item = QtGui.QTreeWidgetItem()
                 item.setText(Key, key)
                 item.setText(Value, value)
                 self.addTopLevelItem(item)
         elif isinstance(value, (list, tuple)):
             if not parent_item:
-                parent_item = QtGui.QTreeWidgetItem(parent=self)
+                parent_item = QtGui.QTreeWidgetItem()
                 parent_item.setText(Key, key)
                 self.addTopLevelItem(parent_item)
 
@@ -88,7 +88,7 @@ class EnvTree(QtGui.QTreeWidget):
                 self.set(key, v, parent_item)
         elif isinstance(value, dict):
             if not parent_item:
-                parent_item = QtGui.QTreeWidgetItem(parent=self)
+                parent_item = QtGui.QTreeWidgetItem()
                 parent_item.setText(Key, key)
                 self.addTopLevelItem(parent_item)
 

--- a/python/cpenv_ui/module_info.py
+++ b/python/cpenv_ui/module_info.py
@@ -47,7 +47,7 @@ class ModuleInfo(QtGui.QWidget):
         self.version = QtGui.QLabel('Version')
         self.size = QtGui.QLabel('Size')
         self.requires = MinimizedList(parent=self)
-        self.requires.setSelectionMode(self.requires.NoSelection)
+        self.requires.setSelectionMode(QtGui.QListView.NoSelection)
         self.requires.setFocusPolicy(QtCore.Qt.NoFocus)
         self.requires_copy = QtGui.QToolButton(
             icon=QtGui.QIcon(res.get_path('copy.png'))
@@ -63,7 +63,7 @@ class ModuleInfo(QtGui.QWidget):
             QtGui.QSizePolicy.Expanding,
         )
         self.environment.setFocusPolicy(QtCore.Qt.NoFocus)
-        self.environment.setSelectionMode(self.environment.NoSelection)
+        self.environment.setSelectionMode(QtGui.QListView.NoSelection)
         self.environment_copy = QtGui.QToolButton(
             icon=QtGui.QIcon(res.get_path('copy.png'))
         )

--- a/python/cpenv_ui/module_list.py
+++ b/python/cpenv_ui/module_list.py
@@ -46,13 +46,13 @@ class ModuleList(QtGui.QTreeWidget):
         # Setup header
         self.setHeaderLabels(['Name', 'Version'])
         header = self.header()
-        header.setSectionResizeMode(header.ResizeToContents)
+        header.setSectionResizeMode(QtGui.QHeaderView.ResizeToContents)
         header.setStretchLastSection(False)
-        header.setSectionResizeMode(Name, header.Stretch)
+        header.setSectionResizeMode(Name, QtGui.QHeaderView.Stretch)
 
         # Selection behavior
-        self.setSelectionMode(self.ExtendedSelection)
-        self.setSelectionBehavior(self.SelectRows)
+        self.setSelectionMode(QtGui.QTreeWidget.ExtendedSelection)
+        self.setSelectionBehavior(QtGui.QTreeWidget.SelectRows)
 
         # Drag and drop settings
         self.setDragDropMode(QtGui.QAbstractItemView.DragDrop)
@@ -96,7 +96,7 @@ class ModuleList(QtGui.QTreeWidget):
         self.version_changed.emit(item.spec_set)
 
     def create_item(self, spec_set):
-        item = QtGui.QTreeWidgetItem(parent=self)
+        item = QtGui.QTreeWidgetItem()
         item.spec_set = spec_set
         item.setText(Name, spec_set.selection.name)
         item.setText(Version, spec_set.selection.version.string)

--- a/python/cpenv_ui/module_selector.py
+++ b/python/cpenv_ui/module_selector.py
@@ -1,26 +1,28 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
+import sys
+import traceback
+
 # Standard library imports
 from collections import OrderedDict
 from functools import partial
 from string import Template
-import sys
-import traceback
 
 # Shotgun imports
 import sgtk
 from sgtk.platform.qt import QtCore, QtGui
 
+from . import res
+
 # Local imports
 from .dialogs import ErrorDialog
-from .env_importer import EnvImporter
 from .env_display import EnvDisplay
+from .env_importer import EnvImporter
 from .env_permissions import EnvPermissions
-from .module_list import ModuleList
 from .module_info import ModuleInfo
+from .module_list import ModuleList
 from .notice import Notice
-from . import res
 
 app = sgtk.platform.current_bundle()
 


### PR DESCRIPTION
Address PySide6 support by fixing calls to Enum class attributes. Also fixes QTreeWidgetItem instantiation by removing parent keyword argument, which is no longer valid in PySide6.

Fixes #35
Fixes #30